### PR TITLE
Fixed bug with `projectPath` CLI argument

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   username:
     description: 'Your unity user name. Required to generate license. Use secrets!'
     default: ''
+  projectPath:
+    description: 'Your unity project path relative to the repository root.'
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ cd $GITHUB_WORKSPACE
 xvfb-run --auto-servernum --server-args='-screen 0 640x480x24' /opt/Unity/Editor/Unity \
 -batchmode \
 -quit \
--projectPath=$(pwd) \
+-projectPath=$(pwd)$INPUT_PROJECT_PATH \
 -executeMethod $INPUT_BUILD_METHOD \
 -logFile /dev/stdout
 

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ cd $GITHUB_WORKSPACE
 xvfb-run --auto-servernum --server-args='-screen 0 640x480x24' /opt/Unity/Editor/Unity \
 -batchmode \
 -quit \
--projectPath $(pwd) \
+-projectPath=$(pwd) \
 -executeMethod $INPUT_BUILD_METHOD \
 -logFile /dev/stdout
 


### PR DESCRIPTION
## Background
When the action is used like that:
```yaml
jobs:
  build:
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@v1
    - name: Build Unity
      uses: ncipollo/unity-action@master
      with:
        username: ***
        password: ***
        license: ${{secrets.license}}
        mode: build
        build_method: ***
```
there is an error:
```
Couldn't set project path to: /github/workspace/github/workspace
```

Seems like the problem is in `projectPath` argument that was passed as
`projectPath /github/workspace` while the correct way is
`projectPath=/github/workspace` (as per [this issue](https://github.com/JetBrains/teamcity-unity-plugin/issues/21)).

This PR addresses the bug and fixes the error.